### PR TITLE
#1 - a \f was missing

### DIFF
--- a/rfc9999.txt
+++ b/rfc9999.txt
@@ -402,3 +402,4 @@ RFC 9999                    R-Type Protocols               November 2018
 
 
 Drapier                     Standards Track                     [Page 6]
+


### PR DESCRIPTION
a \f was missing at the end of the file